### PR TITLE
Add plugin name to exported plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,4 +8,4 @@ module.exports = fp(async function (fastify, opts) {
     fastify.io.close()
     done()
   })
-}, { fastify: '4.x' })
+}, { fastify: '4.x', name: 'fastify-socket.io' })


### PR DESCRIPTION
I ran into this error just now:

```
fastify-plugin: index-auto-0 - expected '3.x' fastify version, '4.0.2' is installed
```

Turns out it came from this plugin, but it's missing the name which made it tricky to debug.

Regarding this PR: https://github.com/alemagio/fastify-socket.io/pull/23, will you plan a release soon @alemagio ?